### PR TITLE
added unit and integration tests for testing login endpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,12 @@
 {
   "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
-  "editor.formatOnPaste": false, // required 
+  "editor.formatOnPaste": false, // required
   "editor.formatOnType": false, // required
-  "editor.formatOnSave": true, // optional 
+  "editor.formatOnSave": true, // optional
   "editor.formatOnSaveMode": "file", // required to format on save
   "files.autoSave": "onFocusChange", // optional but recommended
-  "vs-code-prettier-eslint.prettierLast": "false" // set as "true" to run 'prettier' last not first
+  "vs-code-prettier-eslint.prettierLast": "false", // set as "true" to run 'prettier' last not first
+  "files.exclude": {
+    "**/test.js": true
+  }
 }

--- a/back-end/.eslintrc.cjs
+++ b/back-end/.eslintrc.cjs
@@ -4,53 +4,49 @@ module.exports = {
     es2021: true,
     node: true
   },
-  extends: 'standard',
+  extends: "standard",
   overrides: [
     {
       env: {
         node: true
       },
-      files: [
-        '.eslintrc.{js,cjs}'
-      ],
+      files: [".eslintrc.{js,cjs}", "**/test.js"],
       parserOptions: {
-        sourceType: 'script'
+        sourceType: "script"
       }
     }
   ],
   parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module'
+    ecmaVersion: "latest",
+    sourceType: "module"
   },
   rules: {
-    'semi': [
-      'error',
-      'always'
+    semi: ["error", "always"],
+    "no-var": ["error"],
+    "prefer-const": [
+      "warn",
+      {
+        destructuring: "any",
+        ignoreReadBeforeAssign: false
+      }
     ],
-    'no-var': [
-      'error',
-    ],
-    'prefer-const': ['warn', {
-      'destructuring': 'any',
-      'ignoreReadBeforeAssign': false
-    }],
-    'curly': ['warn'],
-    'eqeqeq': ['error'],
-    'no-multi-spaces': ['warn'],
-    'no-lone-blocks': ['error'],
-    'no-self-compare': ['error'],
-    'no-unused-expressions': ['error'],
-    'no-useless-call': ['error'],
-    'no-use-before-define': ['warn'],
+    curly: ["warn"],
+    eqeqeq: ["error"],
+    "no-multi-spaces": ["warn"],
+    "no-lone-blocks": ["error"],
+    "no-self-compare": ["error"],
+    "no-unused-expressions": ["error"],
+    "no-useless-call": ["error"],
+    "no-use-before-define": ["warn"],
 
-    'camelcase': ['warn', { properties: 'never' }],
-    'func-call-spacing': ['off'],
-    'no-lonely-if': ['off'],
-    'array-bracket-spacing': ['warn'],
+    camelcase: ["warn", { properties: "never" }],
+    "func-call-spacing": ["off"],
+    "no-lonely-if": ["off"],
+    "array-bracket-spacing": ["warn"],
 
-    'no-console': ['off'],
+    "no-console": ["off"],
     "space-before-function-paren": ["off"],
-    "quotes": ["off"],
-    "indent": "off"
+    quotes: ["off"],
+    indent: "off"
   }
-}
+};

--- a/back-end/test/dummy.test.js
+++ b/back-end/test/dummy.test.js
@@ -1,12 +1,14 @@
-import chai from 'chai';
-import { expect } from 'chai';
+/*eslint-disable*/
 
-describe('Sample Test Suite', () => {
-    it('should pass this test', () => {
-        expect(1 + 1).to.equal(2);
-    });
+import chai from "chai";
+import { expect } from "chai";
 
-    it('should fail this test', () => {
-        expect(2 * 2).to.equal(5);
-    });
+describe("Sample Test Suite", () => {
+  it("should pass this test", () => {
+    expect(1 + 1).to.equal(2);
+  });
+
+  it("should fail this test", () => {
+    expect(2 * 2).to.equal(5);
+  });
 });

--- a/back-end/test/login.test.js
+++ b/back-end/test/login.test.js
@@ -1,0 +1,112 @@
+/* eslint-disable */
+
+import chai, { assert } from "chai";
+import sinon from "sinon";
+import {
+  loginStudentHandler,
+  loginAdminHandler
+} from "../src/controllers/loginHandler.js";
+
+// Unit Testing
+describe("Unit Tests for Login Handlers", () => {
+  let req, res, statusSpy, jsonSpy;
+
+  beforeEach(() => {
+    req = { body: {} };
+    res = {
+      json: () => {},
+      status: function (s) {
+        this.statusCode = s;
+        return this;
+      }
+    };
+    statusSpy = sinon.spy(res, "status");
+    jsonSpy = sinon.spy(res, "json");
+  });
+
+  afterEach(() => {
+    statusSpy.restore();
+    jsonSpy.restore();
+  });
+
+  describe("loginStudentHandler", () => {
+    it("should authenticate valid student credentials", () => {
+      req.body = { username: "s", password: "1" };
+      loginStudentHandler(req, res);
+      assert(statusSpy.calledWith(200));
+      assert(jsonSpy.calledWith({ authenticated: true }));
+    });
+
+    it("should not authenticate invalid student credentials", () => {
+      req.body = { username: "wrong", password: "user" };
+      loginStudentHandler(req, res);
+      assert(statusSpy.calledWith(200));
+      assert(jsonSpy.calledWith({ authenticated: false }));
+    });
+  });
+
+  describe("loginAdminHandler", () => {
+    it("should authenticate valid admin credentials", () => {
+      req.body = { username: "a", password: "1" };
+      loginAdminHandler(req, res);
+      assert(jsonSpy.calledWith({ authenticated: true }));
+    });
+
+    it("should not authenticate invalid admin credentials", () => {
+      req.body = { username: "wrong", password: "user" };
+      loginAdminHandler(req, res);
+      assert(jsonSpy.calledWith({ authenticated: false }));
+    });
+  });
+});
+
+//Integration Testing
+
+import chaiHttp from "chai-http";
+import server from "../app.js";
+
+chai.use(chaiHttp);
+
+describe("Integration Tests for Login Endpoints", () => {
+  describe("POST /api/login/student", () => {
+    it("should authenticate student with correct credentials", async () => {
+      const res = await chai
+        .request(server)
+        .post("/api/login/student")
+        .send({ username: "s", password: "1" });
+      assert.equal(res.status, 200);
+      assert.deepEqual(res.body, { authenticated: true });
+    });
+
+    it("should not authenticate student with incorrect credentials", async () => {
+      const res = await chai
+        .request(server)
+        .post("/api/login/student")
+        .send({ username: "wrong", password: "user" });
+      assert.equal(res.status, 200);
+      assert.deepEqual(res.body, { authenticated: false });
+    });
+  });
+
+  describe("POST /api/login/admin", () => {
+    it("should authenticate admin with correct credentials", async () => {
+      const res = await chai
+        .request(server)
+        .post("/api/login/admin")
+        .send({ username: "a", password: "1" });
+      assert.equal(res.status, 200);
+      assert.deepEqual(res.body, { authenticated: true });
+    });
+
+    it("should not authenticate admin with incorrect credentials", async () => {
+      const res = await chai
+        .request(server)
+        .post("/api/login/admin")
+        .send({ username: "wrong", password: "user" });
+      assert.equal(res.status, 200);
+      assert.deepEqual(res.body, { authenticated: false });
+    });
+  });
+});
+
+/* eslint-enable */


### PR DESCRIPTION
**To run integration tests, just run the backend server on one terminal and npm run test on another**

- added unit tests with mocha and chai tdd assertion and sinin
- added integration tests with chai-http
- tested both authentication and authentication failure
- disabled eslint-prettier in code testing files because code formatter was removing large chunks of code.

Closes #205 